### PR TITLE
Don't use subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,27 @@
 atags-cli is command line tool encapsulating partial functions of [audiotags](https://docs.rs/audiotags/latest/audiotags) for editing audio metadata.
 
 ```bash
-atags-cli -h
 Audio metadata command line tool encapsulating partial functions of audiotags
 
-Usage: atags-cli [COMMAND]
-
-Commands:
-  show  Show audio exiting metadata
-  set   Set audio metadata
-  help  Print this message or the help of the given subcommand(s)
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
-```
-
-```bash
-atags-cli set --help
-Set audio metadata
-
-Usage: atags-cli set [OPTIONS] <FILE>
+Usage: atags-cli [OPTIONS] <NAME>
 
 Arguments:
-  <FILE>
+  <NAME>  File Path
 
 Options:
-  -t, --title <TITLE>                Set audio name
-  -a, --artist <ARTIST>              Set audio artist(s)
+  -t, --title <TITLE>                Set audio title
+  -a, --artist <ARTIST>              Set audio artist
   -g, --genre <GENRE>                Set audio genre
   -c, --composer <COMPOSER>          Set audio composer
       --track-number <TRACK_NUMBER>  Set audio track number
       --album-title <ALBUM_TITLE>    Set audio album title
-  -h, --help
-```
-
-```bash
-Show audio exiting metadata
-
-Usage: atags-cli show <FILE>
-
-Arguments:
-  <FILE>
-
-Options:
-  -h, --help  Print help
+  -h, --help                         Print help
+  -V, --version                      Print version
 ```
 
 ### Examples
 
 ```bash
-atags-cli set ./assets/rm1210.m4a -t "rm1210" -a "My Little Airport"
-atags-cli show ./assets/rm1210.m4a
+atags-cli ./assets/rm1210.m4a -t "rm1210" -a "My Little Airport"
+atags-cli ./assets/rm1210.m4a
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,69 +1,41 @@
 mod utils;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use utils::{display::show, edit::set};
 
 pub type PathBuf = std::path::PathBuf;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(version, about)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-}
+struct Commands {
+    /// File Path
+    name: PathBuf,
 
-#[derive(Subcommand)]
-enum Commands {
-    /// Show audio exiting metadata
-    Show { file: PathBuf },
-    /// Set audio metadata
-    Set {
-        file: PathBuf,
-
-        /// Set audio name
-        #[arg(short, long)]
-        title: Option<String>,
-        /// Set audio artist(s)
-        #[arg(short, long)]
-        artist: Option<String>,
-        /// Set audio genre
-        #[arg(short, long)]
-        genre: Option<String>,
-        /// Set audio composer
-        #[arg(short, long)]
-        composer: Option<String>,
-        /// Set audio track number
-        #[arg(long)]
-        track_number: Option<u16>,
-        /// Set audio album title
-        #[arg(long)]
-        album_title: Option<String>,
-    },
+    /// Set audio title
+    #[arg(short, long)]
+    title: Option<String>,
+    /// Set audio artist
+    #[arg(short, long)]
+    artist: Option<String>,
+    /// Set audio genre
+    #[arg(short, long)]
+    genre: Option<String>,
+    /// Set audio composer
+    #[arg(short, long)]
+    composer: Option<String>,
+    /// Set audio track number
+    #[arg(long)]
+    track_number: Option<u16>,
+    /// Set audio album title
+    #[arg(long)]
+    album_title: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
-    if let Some(cli) = cli.command {
-        match cli {
-            Commands::Show { file } => show(&file),
-            Commands::Set {
-                file,
-                title,
-                artist,
-                album_title,
-                genre,
-                composer,
-                track_number,
-            } => set(
-                &file,
-                title,
-                artist,
-                album_title,
-                genre,
-                composer,
-                track_number,
-            ),
-        }
-    }
+    let args = Commands::parse();
+    set(&args);
+    show(&args.name);
+
+    // println!("{:?}", Args);
 
     Ok(())
 }

--- a/src/utils/edit.rs
+++ b/src/utils/edit.rs
@@ -1,44 +1,36 @@
 use audiotags::Tag;
 
-use crate::PathBuf;
+use crate::Commands;
 
-pub fn set(
-    file: &PathBuf,
-    title: Option<String>,
-    artist: Option<String>,
-    album_title: Option<String>,
-    genre: Option<String>,
-    composer: Option<String>,
-    track_number: Option<u16>,
-) {
+pub fn set(args: &Commands) {
     let mut tag = Tag::new()
-        .read_from_path(file)
+        .read_from_path(&args.name)
         .expect("Audio File Not Found");
 
-    if let Some(title) = title {
+    if let Some(title) = &args.title {
         tag.set_title(title.as_str())
     }
 
-    if let Some(album_title) = album_title {
+    if let Some(album_title) = &args.album_title {
         tag.set_album_title(album_title.as_str())
     }
 
-    if let Some(artist) = artist {
+    if let Some(artist) = &args.artist {
         tag.set_artist(artist.as_str())
     }
 
-    if let Some(genre) = genre {
+    if let Some(genre) = &args.genre {
         tag.set_genre(genre.as_str())
     }
 
-    if let Some(composer) = composer {
-        tag.set_composer(composer)
+    if let Some(composer) = &args.composer {
+        tag.set_composer(composer.to_string())
     }
 
-    if let Some(track_number) = track_number {
+    if let Some(track_number) = args.track_number {
         tag.set_track_number(track_number)
     }
 
-    tag.write_to_path(file.as_os_str().to_str().unwrap())
+    tag.write_to_path(args.name.to_str().unwrap())
         .expect("Fail to save");
 }


### PR DESCRIPTION
For Simplicity, I refactored code from sub-commands to single command.

Old version: 
- `atags-cli show xxx.mp3` to display audio information
- `atags-cli set xxx.mp3 -t "demo"` to edit audio information

Latest version:
- `atags-cli xxx.mp3` to display audio information
- `atags-cli xxx.mp3 -t "demo"` to edit audio information